### PR TITLE
close the featureIterator after sampling a feature

### DIFF
--- a/src/main/java/nl/b3p/datastorelinker/gui/stripes/InputAction.java
+++ b/src/main/java/nl/b3p/datastorelinker/gui/stripes/InputAction.java
@@ -255,7 +255,7 @@ public class InputAction extends DefaultAction {
             } else {
                 srcAttrDesc = ds.getFeatureSource(tableName).getSchema().getAttributeDescriptors();
             }            
-            
+
             List<AttributeDescriptor> attrDescs = new ArrayList<AttributeDescriptor>(srcAttrDesc.size());
             for (AttributeDescriptor ad : srcAttrDesc) {
                 attrDescs.add(ad);
@@ -361,7 +361,7 @@ public class InputAction extends DefaultAction {
             if (iterator.hasNext())
                 return (SimpleFeature)iterator.next();
         } finally {
-            //fc.close(iterator);
+            iterator.close();
         }
 
         throw new Exception("Geen features gevonden.");


### PR DESCRIPTION
otherwise the datastore for a shapefile is not correctly closed..

If the iterator is not closed geotools holds a lock on the file:

[Finalizer] ERROR org.geotools.data.shapefile - The following locker still has a lock: read on file:/home/martijn/apps/datastorelinker_upload/airportheli/airportheliport.shp by org.geotools.data.shapefile.shp.ShapefileReader