### PR TITLE
'expandDirs automatically' can now be set in the web.xml; default false

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -167,6 +167,10 @@
         <param-value>/mnt/tera1/tmp/DSLtest</param-value>
     </context-param>
     <context-param>
+        <param-name>expandAllDirsDirectly</param-name>
+        <param-value>false</param-value>
+    </context-param>
+    <context-param>
         <param-name>defaultSmtpHost</param-name>
         <param-value>kmail.b3partners.nl</param-value>
     </context-param>


### PR DESCRIPTION
If the uploadDirectory is set on a high level, the datastorelinker will search all sub dirs for files. This causes a memory leak if it's a big directory. It is now configurable to let the datastorelinker search all sub dirs directly or only on click like a normal file explorer.