### PR TITLE
upgrade naar geotools 20.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.b3p</groupId>
     <artifactId>datastorelinker</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>datastorelinker</name>
     <properties>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>datastorelinker-bom</artifactId>
-                <version>5.0.8</version>
+                <version>5.1.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>b3p-commons-core</artifactId>
-            <version>5.0.1</version>
+            <version>5.0.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.persistence</groupId>
@@ -64,14 +64,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>datastorelinkerEntities</artifactId>
-            <version>5.0.0</version>
+            <version>5.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>b3p-datastorelinker</artifactId>
-            <version>5.0.1</version>
+            <version>5.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -84,7 +88,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>b3p-commons-gis</artifactId>
-            <version>5.0.5</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <!-- override de oudere versie die met

--- a/src/main/java/nl/b3p/test/AddressToPoint.java
+++ b/src/main/java/nl/b3p/test/AddressToPoint.java
@@ -1,11 +1,11 @@
 package nl.b3p.test;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/webapp/scripts/actions.js
+++ b/src/main/webapp/scripts/actions.js
@@ -373,10 +373,10 @@ attributeTypeJavaClasses = {
     "java.lang.Double": {},
     "java.lang.Short": {},
     "java.util.Date": {},
-    "com.vividsolutions.jts.geom.Polygon": {},
-    "com.vividsolutions.jts.geom.MultiPolygon": {},
-    "com.vividsolutions.jts.geom.Point": {},
-    "com.vividsolutions.jts.geom.MultiPoint": {},
-    "com.vividsolutions.jts.geom.LineString": {},
-    "com.vividsolutions.jts.geom.MultiLineString": {}
+    "org.locationtech.jts.geom.Polygon": {},
+    "org.locationtech.jts.geom.MultiPolygon": {},
+    "org.locationtech.jts.geom.Point": {},
+    "org.locationtech.jts.geom.MultiPoint": {},
+    "org.locationtech.jts.geom.LineString": {},
+    "org.locationtech.jts.geom.MultiLineString": {}
 };


### PR DESCRIPTION
Door het aanpassen van de package namen van de JTS klassen (com.vividsolutions -> org.locationtech) zullen bij een upgrade deze namen in de jobs aangepast moeten worden naar de nieuwe klasse namen, zie bb11f2b340d7831e71dcdc9a0aa5003669626a2e in #42 
```diff
-    "com.vividsolutions.jts.geom.Polygon": {},
-    "com.vividsolutions.jts.geom.MultiPolygon": {},
-    "com.vividsolutions.jts.geom.Point": {},
-    "com.vividsolutions.jts.geom.MultiPoint": {},
-    "com.vividsolutions.jts.geom.LineString": {},
-    "com.vividsolutions.jts.geom.MultiLineString": {}
+    "org.locationtech.jts.geom.Polygon": {},
+    "org.locationtech.jts.geom.MultiPolygon": {},
+    "org.locationtech.jts.geom.Point": {},
+    "org.locationtech.jts.geom.MultiPoint": {},
+    "org.locationtech.jts.geom.LineString": {},
+    "org.locationtech.jts.geom.MultiLineString": {}
```